### PR TITLE
Add support for pod subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,16 @@ module "rsc_managed_exocompute" {
 
 ## Examples
 - [Basic Exocompute](examples/basic)
+- [Pod Subnets](examples/pod_subnets)
 - [Private Exocompute](examples/private)
 - [With Cloud Native AWS Module](examples/with_cloud_native_aws_module)
 
 # Changelog
+
+## v0.4.0
+* Add support for pod subnets via the `aws_exocompute_pod_subnet_1_cidr` and `aws_exocompute_pod_subnet_2_cidr`
+  variables.
+* Add pod subnets example.
 
 ## v0.3.0
 * Add support for selecting the EKS cluster access type via the `rsc_aws_exocompute_cluster_access` variable.
@@ -92,6 +98,8 @@ removed.
 | [aws_route_table_association.rsc_exocompute_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_security_group.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_subnet.rsc_exocompute_pod_subnet_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.rsc_exocompute_pod_subnet_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.rsc_exocompute_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.rsc_exocompute_subnet_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.rsc_exocompute_subnet_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
@@ -120,6 +128,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_exocompute_pod_subnet_1_cidr"></a> [aws\_exocompute\_pod\_subnet\_1\_cidr](#input\_aws\_exocompute\_pod\_subnet\_1\_cidr) | Pod subnet 1 CIDR for the AWS account hosting Exocompute. | `string` | `null` | no |
+| <a name="input_aws_exocompute_pod_subnet_2_cidr"></a> [aws\_exocompute\_pod\_subnet\_2\_cidr](#input\_aws\_exocompute\_pod\_subnet\_2\_cidr) | Pod subnet 2 CIDR for the AWS account hosting Exocompute. | `string` | `null` | no |
 | <a name="input_aws_exocompute_public_subnet_cidr"></a> [aws\_exocompute\_public\_subnet\_cidr](#input\_aws\_exocompute\_public\_subnet\_cidr) | Public subnet CIDR for the AWS account hosting Exocompute. | `string` | n/a | yes |
 | <a name="input_aws_exocompute_subnet_1_cidr"></a> [aws\_exocompute\_subnet\_1\_cidr](#input\_aws\_exocompute\_subnet\_1\_cidr) | Subnet 1 CIDR for the AWS account hosting Exocompute. | `string` | n/a | yes |
 | <a name="input_aws_exocompute_subnet_2_cidr"></a> [aws\_exocompute\_subnet\_2\_cidr](#input\_aws\_exocompute\_subnet\_2\_cidr) | Subnet 2 CIDR for the AWS account hosting Exocompute. | `string` | n/a | yes |

--- a/examples/pod_subnets/README.md
+++ b/examples/pod_subnets/README.md
@@ -1,0 +1,49 @@
+# RSC Managed Exocompute with Pod Subnets
+The configuration in this directory creates a VPC with dedicated pod subnets in AWS and an Exocompute configuration in
+RSC for RSC managed Exocompute.
+
+## Usage
+To run this example you need to execute:
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+Note that this example may create resources which can cost money. Run `terraform destroy` when you don't need these
+resources.
+
+<!-- BEGIN_TF_DOCS -->
+
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=5.26.0 |
+| <a name="requirement_polaris"></a> [polaris](#requirement\_polaris) | >=1.5.0 |
+
+## Providers
+
+No providers.
+
+## Resources
+
+No resources.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_rsc_managed_exocompute"></a> [rsc\_managed\_exocompute](#module\_rsc\_managed\_exocompute) | ../../ | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_example_account_id"></a> [example\_account\_id](#input\_example\_account\_id) | RSC cloud account ID for the AWS account hosting Exocompute. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+
+<!-- END_TF_DOCS -->

--- a/examples/pod_subnets/main.tf
+++ b/examples/pod_subnets/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=5.26.0"
+    }
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = ">=1.5.0"
+    }
+  }
+}
+
+variable "example_account_id" {
+  type        = string
+  description = "RSC cloud account ID for the AWS account hosting Exocompute."
+}
+
+provider "aws" {}
+
+provider "polaris" {}
+
+module "rsc_managed_exocompute" {
+  source = "../../"
+
+  aws_exocompute_public_subnet_cidr  = "172.20.0.0/24"
+  aws_exocompute_subnet_1_cidr       = "172.20.1.0/24"
+  aws_exocompute_subnet_2_cidr       = "172.20.2.0/24"
+  aws_exocompute_pod_subnet_1_cidr   = "172.20.3.0/24"
+  aws_exocompute_pod_subnet_2_cidr   = "172.20.4.0/24"
+  aws_exocompute_vpc_cidr            = "172.20.0.0/16"
+  rsc_aws_cnp_account_id             = var.example_account_id
+
+  tags = {
+    Environment = "test"
+    Example     = "pod_subnets"
+    Module      = "terraform-aws-polaris-cloud-native-rsc-managed-exocompute"
+  }
+}

--- a/gen_docs.sh
+++ b/gen_docs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 terraform-docs markdown table --hide-empty --output-file README.md --sort .
 terraform-docs markdown table --hide-empty --output-file README.md --sort ./examples/basic
+terraform-docs markdown table --hide-empty --output-file README.md --sort ./examples/pod_subnets
 terraform-docs markdown table --hide-empty --output-file README.md --sort ./examples/private
 terraform-docs markdown table --hide-empty --output-file README.md --sort ./examples/with_cloud_native_aws_module

--- a/main.tf
+++ b/main.tf
@@ -9,8 +9,19 @@ resource "polaris_aws_exocompute" "rsc_managed" {
   region                    = data.aws_region.current.name
   vpc_id                    = aws_vpc.rsc_exocompute.id
 
-  subnets = [
+  subnets = var.aws_exocompute_pod_subnet_1_cidr == null ? [
     aws_subnet.rsc_exocompute_subnet_1.id,
-    aws_subnet.rsc_exocompute_subnet_2.id
-  ]
+    aws_subnet.rsc_exocompute_subnet_2.id,
+  ] : null
+
+  dynamic "subnet" {
+    for_each = var.aws_exocompute_pod_subnet_1_cidr != null ? [
+      { subnet_id = aws_subnet.rsc_exocompute_subnet_1.id, pod_subnet_id = aws_subnet.rsc_exocompute_pod_subnet_1[0].id },
+      { subnet_id = aws_subnet.rsc_exocompute_subnet_2.id, pod_subnet_id = aws_subnet.rsc_exocompute_pod_subnet_2[0].id },
+    ] : []
+    content {
+      subnet_id     = subnet.value.subnet_id
+      pod_subnet_id = subnet.value.pod_subnet_id
+    }
+  }
 }

--- a/networking.tf
+++ b/networking.tf
@@ -230,10 +230,37 @@ resource "aws_route_table_association" "rsc_exocompute_private_1" {
   route_table_id = aws_route_table.rsc_exocompute_private.id
 }
 
-
 resource "aws_route_table_association" "rsc_exocompute_private_2" {
   subnet_id      = aws_subnet.rsc_exocompute_subnet_2.id
   route_table_id = aws_route_table.rsc_exocompute_private.id
+}
+
+# Pod subnets.
+
+resource "aws_subnet" "rsc_exocompute_pod_subnet_1" {
+  count = var.aws_exocompute_pod_subnet_1_cidr != null ? 1 : 0
+
+  vpc_id                  = aws_vpc.rsc_exocompute.id
+  cidr_block              = var.aws_exocompute_pod_subnet_1_cidr
+  availability_zone       = "${data.aws_region.current.name}a"
+  map_public_ip_on_launch = false
+
+  tags = merge({
+    Name = "Rubrik Exocompute Pod Subnet 1"
+  }, var.tags)
+}
+
+resource "aws_subnet" "rsc_exocompute_pod_subnet_2" {
+  count = var.aws_exocompute_pod_subnet_2_cidr != null ? 1 : 0
+
+  vpc_id                  = aws_vpc.rsc_exocompute.id
+  cidr_block              = var.aws_exocompute_pod_subnet_2_cidr
+  availability_zone       = "${data.aws_region.current.name}b"
+  map_public_ip_on_launch = false
+
+  tags = merge({
+    Name = "Rubrik Exocompute Pod Subnet 2"
+  }, var.tags)
 }
 
 # EKS cluster security groups.

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,32 @@ variable "rsc_aws_exocompute_cluster_access" {
   }
 }
 
+variable "aws_exocompute_pod_subnet_1_cidr" {
+  type        = string
+  default     = null
+  description = "Pod subnet 1 CIDR for the AWS account hosting Exocompute."
+
+  validation {
+    condition     = var.aws_exocompute_pod_subnet_1_cidr == null || can(cidrhost(var.aws_exocompute_pod_subnet_1_cidr, 0))
+    error_message = "Must be a valid CIDR address."
+  }
+}
+
+variable "aws_exocompute_pod_subnet_2_cidr" {
+  type        = string
+  default     = null
+  description = "Pod subnet 2 CIDR for the AWS account hosting Exocompute."
+
+  validation {
+    condition     = var.aws_exocompute_pod_subnet_2_cidr == null || can(cidrhost(var.aws_exocompute_pod_subnet_2_cidr, 0))
+    error_message = "Must be a valid CIDR address."
+  }
+  validation {
+    condition     = (var.aws_exocompute_pod_subnet_2_cidr == null) == (var.aws_exocompute_pod_subnet_1_cidr == null)
+    error_message = "Pod subnet 1 CIDR and pod subnet 2 CIDR must be specified together."
+  }
+}
+
 variable "tags" {
   type        = map(string)
   default     = null


### PR DESCRIPTION
## Summary

- Add optional `aws_exocompute_pod_subnet_1_cidr` and `aws_exocompute_pod_subnet_2_cidr` variables for specifying dedicated pod subnets. Both must be specified together or both omitted.
- When pod subnet CIDRs are provided, the module creates the subnets and uses dynamic `subnet` blocks on the `polaris_aws_exocompute` resource to pair each node subnet with its corresponding pod subnet.
- When omitted, existing behavior is unchanged (simple `subnets` list).
- Add `pod_subnets` example.

## Test plan

- [x] Deployed the `basic` example (no pod subnets) to verify backward compatibility
- [x] Deployed the `pod_subnets` example to verify pod subnet creation and Exocompute configuration